### PR TITLE
chore: downgrade minimum java version to 17

### DIFF
--- a/walking-skeleton/pom.xml
+++ b/walking-skeleton/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>17</java.version>
         <vaadin.version>24.8.0.alpha3</vaadin.version>
         <archunit.version>1.3.0</archunit.version>
     </properties>


### PR DESCRIPTION
Java 17 is the minimum JDK required for v24 series. We dont have right now agents with JDK 21 in TC

