### PR TITLE
Better Control Center support

### DIFF
--- a/assembly/src/assembly/empty-skeleton.xml
+++ b/assembly/src/assembly/empty-skeleton.xml
@@ -27,6 +27,7 @@
                 <include>mvnw</include>
                 <include>mvnw.cmd</include>
                 <include>pom.xml</include>
+                <include>Dockerfile</include>
             </includes>
             <excludes>
                 <exclude>src/main/bundles/**</exclude>

--- a/assembly/src/assembly/flow-skeleton.xml
+++ b/assembly/src/assembly/flow-skeleton.xml
@@ -24,6 +24,7 @@
                 <include>mvnw</include>
                 <include>mvnw.cmd</include>
                 <include>pom.xml</include>
+                <include>Dockerfile</include>
             </includes>
             <excludes>
                 <exclude>src/main/bundles/**</exclude>

--- a/assembly/src/assembly/hilla-skeleton.xml
+++ b/assembly/src/assembly/hilla-skeleton.xml
@@ -28,6 +28,7 @@
                 <include>mvnw</include>
                 <include>mvnw.cmd</include>
                 <include>pom.xml</include>
+                <include>Dockerfile</include>
             </includes>
             <excludes>
                 <exclude>src/main/bundles/**</exclude>

--- a/assembly/src/assembly/hybrid-skeleton.xml
+++ b/assembly/src/assembly/hybrid-skeleton.xml
@@ -28,6 +28,7 @@
                 <include>mvnw</include>
                 <include>mvnw.cmd</include>
                 <include>pom.xml</include>
+                <include>Dockerfile</include>
             </includes>
             <excludes>
                 <exclude>src/main/java/com/example/application/base/ui/view/MainLayout.java</exclude>

--- a/walking-skeleton/Dockerfile
+++ b/walking-skeleton/Dockerfile
@@ -1,0 +1,4 @@
+FROM eclipse-temurin:21-jre
+COPY target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/walking-skeleton/pom.xml
+++ b/walking-skeleton/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.3</version>
+        <version>3.4.5</version>
         <relativePath/>
     </parent>
 
@@ -45,6 +45,12 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <!-- Remove this dependency if you don't intend to use Vaadin Control Center -->
+            <!-- See https://vaadin.com/docs/latest/control-center for more information -->
+            <groupId>com.vaadin</groupId>
+            <artifactId>control-center-starter</artifactId>
         </dependency>
 
         <!-- Persistence -->

--- a/walking-skeleton/src/main/frontend/views/@layout.tsx
+++ b/walking-skeleton/src/main/frontend/views/@layout.tsx
@@ -4,6 +4,7 @@ import {
   Avatar,
   Icon,
   MenuBar,
+  MenuBarItem,
   MenuBarItemSelectedEvent,
   ProgressBar,
   Scroller,
@@ -39,9 +40,11 @@ function MainMenu() {
   );
 }
 
+type UserMenuItem = MenuBarItem<{ action?: () => void }>;
+
 function UserMenu() {
   // TODO Replace with real user information and actions
-  const items = [
+  const items: Array<UserMenuItem> = [
     {
       component: (
         <>
@@ -49,17 +52,14 @@ function UserMenu() {
         </>
       ),
       children: [
-        { text: 'View Profile', action: () => console.log('View Profile') },
-        { text: 'Manage Settings', action: () => console.log('Manage Settings') },
-        { text: 'Logout', action: () => console.log('Logout') },
+        { text: 'View Profile', disabled: true, action: () => console.log('View Profile') },
+        { text: 'Manage Settings', disabled: true, action: () => console.log('Manage Settings') },
+        { text: 'Logout', disabled: true, action: () => console.log('Logout') },
       ],
     },
   ];
-  const onItemSelected = (event: MenuBarItemSelectedEvent) => {
-    const action = (event.detail.value as any).action;
-    if (action) {
-      action();
-    }
+  const onItemSelected = (event: MenuBarItemSelectedEvent<UserMenuItem>) => {
+    event.detail.value.action?.();
   };
   return (
     <MenuBar theme="tertiary-inline" items={items} onItemSelected={onItemSelected} className="m-m" slot="drawer" />

--- a/walking-skeleton/src/main/java/com/example/application/base/ui/view/MainLayout.java
+++ b/walking-skeleton/src/main/java/com/example/application/base/ui/view/MainLayout.java
@@ -16,10 +16,12 @@ import com.vaadin.flow.component.sidenav.SideNavItem;
 import com.vaadin.flow.router.Layout;
 import com.vaadin.flow.server.menu.MenuConfiguration;
 import com.vaadin.flow.server.menu.MenuEntry;
+import jakarta.annotation.security.PermitAll;
 
 import static com.vaadin.flow.theme.lumo.LumoUtility.*;
 
 @Layout
+@PermitAll // When security is enabled, allow all authenticated users
 public final class MainLayout extends AppLayout {
 
     MainLayout() {
@@ -68,9 +70,9 @@ public final class MainLayout extends AppLayout {
 
         var userMenuItem = userMenu.addItem(avatar);
         userMenuItem.add("John Smith");
-        userMenuItem.getSubMenu().addItem("View Profile");
-        userMenuItem.getSubMenu().addItem("Manage Settings");
-        userMenuItem.getSubMenu().addItem("Logout");
+        userMenuItem.getSubMenu().addItem("View Profile").setEnabled(false);
+        userMenuItem.getSubMenu().addItem("Manage Settings").setEnabled(false);
+        userMenuItem.getSubMenu().addItem("Logout").setEnabled(false);
 
         return userMenu;
     }

--- a/walking-skeleton/src/main/java/com/example/application/base/ui/view/MainView.java
+++ b/walking-skeleton/src/main/java/com/example/application/base/ui/view/MainView.java
@@ -7,11 +7,14 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Main;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.lumo.LumoUtility;
+import jakarta.annotation.security.PermitAll;
 
 /**
- * This view shows up when a user navigates to the root ('/') of the application.
+ * This view shows up when a user navigates to the root ('/') of the
+ * application.
  */
 @Route
+@PermitAll // When security is enabled, allow all authenticated users
 public final class MainView extends Main {
 
     // TODO Replace with your own main view.

--- a/walking-skeleton/src/main/java/com/example/application/taskmanagement/ui/view/TaskListView.java
+++ b/walking-skeleton/src/main/java/com/example/application/taskmanagement/ui/view/TaskListView.java
@@ -15,6 +15,7 @@ import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.lumo.LumoUtility;
+import jakarta.annotation.security.PermitAll;
 
 import java.time.Clock;
 import java.time.format.DateTimeFormatter;
@@ -26,6 +27,7 @@ import static com.vaadin.flow.spring.data.VaadinSpringDataHelpers.toSpringPageRe
 @Route("task-list-flow")
 @PageTitle("Task List Flow")
 @Menu(order = 0, icon = "vaadin:clipboard-check", title = "Task List Flow")
+@PermitAll // When security is enabled, allow all authenticated users
 public class TaskListView extends Main {
 
     private final TaskService taskService;


### PR DESCRIPTION
This PR improves support for Control Center out of the box by:
- Adding the control center dependency to the pom.xml
- Adding sensible default security annotations to the main layout and views
- Adding a Dockerfile to the generated skeleton

It also includes some minor refactoring of the main layouts (both Hilla and Flow versions).