### PR TITLE
Automatically include Control Center only in the Flow skeleton.

### DIFF
--- a/assembly/src/assembly/flow-skeleton.xml
+++ b/assembly/src/assembly/flow-skeleton.xml
@@ -23,7 +23,6 @@
                 <include>LICENSE.md</include>
                 <include>mvnw</include>
                 <include>mvnw.cmd</include>
-                <include>pom.xml</include>
                 <include>Dockerfile</include>
             </includes>
             <excludes>
@@ -35,4 +34,12 @@
             </excludes>
         </fileSet>
     </fileSets>
+    <!-- At the moment, Control Center only works with Flow apps. Adding its dependency to a Hilla app will break the production build. -->
+    <files>
+        <file>
+            <source>${basedir}/../walking-skeleton/pom-with-control-center.xml</source>
+            <outputDirectory/>
+            <destName>pom.xml</destName>
+        </file>
+    </files>
 </assembly>

--- a/walking-skeleton/pom-with-control-center.xml
+++ b/walking-skeleton/pom-with-control-center.xml
@@ -46,6 +46,12 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring-boot-starter</artifactId>
         </dependency>
+        <dependency>
+            <!-- Remove this dependency if you don't intend to use Vaadin Control Center -->
+            <!-- See https://vaadin.com/docs/latest/control-center for more information -->
+            <groupId>com.vaadin</groupId>
+            <artifactId>control-center-starter</artifactId>
+        </dependency>
 
         <!-- Persistence -->
         <dependency>


### PR DESCRIPTION
CC is not yet working with Hilla (but it will in a later version). This PR only adds the CC dependency to the Flow skeleton.