### PR TITLE
Update pom-with-control-center.xml

### DIFF
--- a/walking-skeleton/pom-with-control-center.xml
+++ b/walking-skeleton/pom-with-control-center.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <vaadin.version>24.8.0.alpha6</vaadin.version>
+        <vaadin.version>24.7.3</vaadin.version>
         <archunit.version>1.3.0</archunit.version>
     </properties>
 


### PR DESCRIPTION
The cherry pick to 24.7 had the wrong Vaadin version in the new pom.xml that will be used in Flow projects. I didn't notice until it was merged.