### PR TITLE
Add support for Testcontainers to the skeleton

### DIFF
--- a/walking-skeleton/pom-with-control-center.xml
+++ b/walking-skeleton/pom-with-control-center.xml
@@ -13,7 +13,7 @@
     <properties>
         <java.version>17</java.version>
         <vaadin.version>24.8.0.alpha6</vaadin.version>
-        <archunit.version>1.3.0</archunit.version>
+        <archunit.version>1.4.1</archunit.version>
     </properties>
 
     <parent>
@@ -84,6 +84,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/walking-skeleton/pom.xml
+++ b/walking-skeleton/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <java.version>17</java.version>
         <vaadin.version>24.8.0.alpha6</vaadin.version>
-        <archunit.version>1.3.0</archunit.version>
+        <archunit.version>1.4.1</archunit.version>
     </properties>
 
     <parent>
@@ -78,6 +78,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/walking-skeleton/src/test/java/com/example/application/TestApplication.java
+++ b/walking-skeleton/src/test/java/com/example/application/TestApplication.java
@@ -3,9 +3,8 @@ package com.example.application;
 import org.springframework.boot.SpringApplication;
 
 /**
- * Run this application class to use Testcontainers for all your external services. This is convenient during
- * development as you don't have to have your database or message broker running locally. They will instead start
- * up in temporary Docker containers when you start the application.
+ * Run this application class to start your application locally, using Testcontainers for all external services.
+ * You have to configure the containers in {@link TestcontainersConfiguration}.
  */
 public class TestApplication {
 

--- a/walking-skeleton/src/test/java/com/example/application/TestApplication.java
+++ b/walking-skeleton/src/test/java/com/example/application/TestApplication.java
@@ -1,0 +1,15 @@
+package com.example.application;
+
+import org.springframework.boot.SpringApplication;
+
+/**
+ * Run this application class to use Testcontainers for all your external services. This is convenient during
+ * development as you don't have to have your database or message broker running locally. They will instead start
+ * up in temporary Docker containers when you start the application.
+ */
+public class TestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.from(Application::main).with(TestcontainersConfiguration.class).run(args);
+    }
+}

--- a/walking-skeleton/src/test/java/com/example/application/TestcontainersConfiguration.java
+++ b/walking-skeleton/src/test/java/com/example/application/TestcontainersConfiguration.java
@@ -1,0 +1,10 @@
+package com.example.application;
+
+import org.springframework.boot.test.context.TestConfiguration;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestcontainersConfiguration {
+
+    // TODO Configure your Testcontainers here.
+    //  See https://docs.spring.io/spring-boot/reference/testing/testcontainers.html for details.
+}

--- a/walking-skeleton/src/test/java/com/example/application/taskmanagement/service/TaskServiceIT.java
+++ b/walking-skeleton/src/test/java/com/example/application/taskmanagement/service/TaskServiceIT.java
@@ -1,5 +1,6 @@
 package com.example.application.taskmanagement.service;
 
+import com.example.application.TestcontainersConfiguration;
 import com.example.application.taskmanagement.domain.Task;
 import com.example.application.taskmanagement.domain.TaskRepository;
 import jakarta.validation.ValidationException;
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,7 @@ import java.time.LocalDate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@Import(TestcontainersConfiguration.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 class TaskServiceIT {


### PR DESCRIPTION
This PR adds basic Testcontainers support to the skeleton, making it easier to e.g. configure a PostgreSQL container for testing and local development.