### PR TITLE
Replace @ArchTest with classic @Test

### DIFF
--- a/walking-skeleton/src/test/java/com/example/application/ArchitectureTest.java
+++ b/walking-skeleton/src/test/java/com/example/application/ArchitectureTest.java
@@ -1,8 +1,8 @@
 package com.example.application;
 
-import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.jupiter.api.Test;
 import org.springframework.data.repository.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,39 +10,46 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
-@AnalyzeClasses(packages = ArchitectureTest.BASE_PACKAGE)
 class ArchitectureTest {
 
     static final String BASE_PACKAGE = "com.example.application";
 
+    private final JavaClasses importedClasses = new ClassFileImporter().importPackages(BASE_PACKAGE);
+
     // TODO Add your own rules and remove those that don't apply to your project
 
-    @ArchTest
-    public static final ArchRule domain_model_should_not_depend_on_application_services = noClasses().that()
-            .resideInAPackage(BASE_PACKAGE + "..domain..").should().dependOnClassesThat()
-            .resideInAPackage(BASE_PACKAGE + "..service..");
+    @Test
+    void domain_model_should_not_depend_on_application_services() {
+        noClasses().that().resideInAPackage(BASE_PACKAGE + "..domain..").should().dependOnClassesThat()
+                .resideInAPackage(BASE_PACKAGE + "..service..").check(importedClasses);
+    }
 
-    @ArchTest
-    public static final ArchRule domain_model_should_not_depend_on_the_user_interface = noClasses().that()
-            .resideInAPackage(BASE_PACKAGE + "..domain..").should().dependOnClassesThat()
-            .resideInAnyPackage(BASE_PACKAGE + "..ui..");
+    @Test
+    void domain_model_should_not_depend_on_the_user_interface() {
+        noClasses().that().resideInAPackage(BASE_PACKAGE + "..domain..").should().dependOnClassesThat()
+                .resideInAnyPackage(BASE_PACKAGE + "..ui..").check(importedClasses);
+    }
 
-    @ArchTest
-    public static final ArchRule repositories_should_only_be_used_by_application_services_and_other_domain_classes = classes()
-            .that().areAssignableTo(Repository.class).should().onlyHaveDependentClassesThat()
-            .resideInAnyPackage(BASE_PACKAGE + "..domain..", BASE_PACKAGE + "..service..");
+    @Test
+    void repositories_should_only_be_used_by_application_services_and_other_domain_classes() {
+        classes().that().areAssignableTo(Repository.class).should().onlyHaveDependentClassesThat()
+                .resideInAnyPackage(BASE_PACKAGE + "..domain..", BASE_PACKAGE + "..service..").check(importedClasses);
+    }
 
-    @ArchTest
-    public static final ArchRule repositories_should_only_be_accessed_by_transactional_classes = classes().that()
-            .areAssignableTo(Repository.class).should().onlyBeAccessed().byClassesThat()
-            .areAnnotatedWith(Transactional.class);
+    @Test
+    void repositories_should_only_be_accessed_by_transactional_classes() {
+        classes().that().areAssignableTo(Repository.class).should().onlyBeAccessed().byClassesThat()
+                .areAnnotatedWith(Transactional.class).check(importedClasses);
+    }
 
-    @ArchTest
-    public static final ArchRule application_services_should_not_depend_on_the_user_interface = noClasses().that()
-            .resideInAPackage(BASE_PACKAGE + "..service..").should().dependOnClassesThat()
-            .resideInAnyPackage(BASE_PACKAGE + "..ui..");
+    @Test
+    void application_services_should_not_depend_on_the_user_interface() {
+        noClasses().that().resideInAPackage(BASE_PACKAGE + "..service..").should().dependOnClassesThat()
+                .resideInAnyPackage(BASE_PACKAGE + "..ui..").check(importedClasses);
+    }
 
-    @ArchTest
-    public static final ArchRule there_should_not_be_circular_dependencies_between_feature_packages = slices()
-            .matching(BASE_PACKAGE + ".(*)..").should().beFreeOfCycles();
+    @Test
+    void there_should_not_be_circular_dependencies_between_feature_packages() {
+        slices().matching(BASE_PACKAGE + ".(*)..").should().beFreeOfCycles().check(importedClasses);
+    }
 }


### PR DESCRIPTION
Maven's test runner does not execute the newer annotation-based rules. Replacing them with classic `@Test` rules instead.
