### PR TITLE
Decouple Vaadin production mode from Spring Boot production mode

### DIFF
--- a/walking-skeleton/Dockerfile
+++ b/walking-skeleton/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:21-jre
 COPY target/*.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-jar", "/app.jar", "--spring.profiles.active=prod"]

--- a/walking-skeleton/README.md
+++ b/walking-skeleton/README.md
@@ -15,6 +15,12 @@ To build the application in production mode, run:
 ./mvnw -Pproduction package
 ```
 
+To also build a Docker image, continue by running:
+
+```bash
+docker build -t my-application:latest .
+```
+
 ## Getting Started
 
 The [Getting Started](https://vaadin.com/docs/latest/getting-started) guide will quickly familiarize you with your new

--- a/walking-skeleton/src/main/java/com/example/application/security/controlcenter/ControlCenterSecurityConfig.java
+++ b/walking-skeleton/src/main/java/com/example/application/security/controlcenter/ControlCenterSecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatfo
 import org.springframework.boot.cloud.CloudPlatform;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
@@ -23,7 +24,8 @@ import org.springframework.util.StringUtils;
  * </p>
  *
  * <p>
- * The configuration is conditionally activated when the application is deployed on the Kubernetes platform.
+ * The configuration is conditionally activated when the application is deployed on the Kubernetes platform
+ * <strong>and</strong> the {@code prod} Spring profile is active.
  * </p>
  *
  * <p>
@@ -36,7 +38,8 @@ import org.springframework.util.StringUtils;
 @EnableWebSecurity
 @Configuration
 @ConditionalOnCloudPlatform(CloudPlatform.KUBERNETES)
-public class ControlCenterSecurityConfig extends IdentityManagementConfiguration {
+@Profile("prod")
+class ControlCenterSecurityConfig extends IdentityManagementConfiguration {
 
     /**
      * Creates and configures an OIDC user service with custom user mapping for the application.

--- a/walking-skeleton/src/main/java/com/example/application/security/dev/DevSecurityConfig.java
+++ b/walking-skeleton/src/main/java/com/example/application/security/dev/DevSecurityConfig.java
@@ -1,16 +1,17 @@
 package com.example.application.security.dev;
 
-import com.example.application.security.controlcenter.ControlCenterSecurityConfig;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.spring.security.VaadinAwareSecurityContextHolderStrategyConfiguration;
 import com.vaadin.flow.spring.security.VaadinSecurityConfigurer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.cloud.CloudPlatform;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -27,7 +28,7 @@ import org.springframework.security.web.SecurityFilterChain;
  * </ul>
  * </p>
  * <p>
- * This configuration is automatically activated when {@link ControlCenterSecurityConfig} is not active. It should
+ * This configuration is automatically activated when the {@code prod} Spring profile is not active. It should
  * <strong>not</strong> be used in production environments, as it uses hardcoded credentials and simplified security
  * settings.
  * </p>
@@ -46,13 +47,20 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 @Configuration
 @Import({ VaadinAwareSecurityContextHolderStrategyConfiguration.class })
-@ConditionalOnMissingBean(ControlCenterSecurityConfig.class)
+@Profile("!prod")
 class DevSecurityConfig {
 
     private static final Logger log = LoggerFactory.getLogger(DevSecurityConfig.class);
 
-    DevSecurityConfig() {
-        log.warn("Using DEVELOPMENT security configuration. This should not be used in production environments!");
+    DevSecurityConfig(Environment environment) {
+        if (!isRunningLocally(environment)) {
+            log.error("Development security config attempted in non-local environment");
+            throw new IllegalStateException("Development security can only be used when running locally");
+        }
+        log.warn("╔═════════════════════════════════════════════════════════════╗");
+        log.warn("║                     DEVELOPMENT SECURITY                    ║");
+        log.warn("║ This should not be used in production environments.         ║");
+        log.warn("╚═════════════════════════════════════════════════════════════╝");
     }
 
     @Bean
@@ -70,11 +78,23 @@ class DevSecurityConfig {
     VaadinServiceInitListener developmentLoginConfigurer() {
         return (serviceInitEvent) -> {
             if (serviceInitEvent.getSource().getDeploymentConfiguration().isProductionMode()) {
-                throw new IllegalStateException(
-                        "Development profile is active but Vaadin is running in production mode. This indicates a configuration error - development profile should not be used in production.");
+                log.warn("╔════════════════════════════════════════════════════════════════════════════════════════╗");
+                log.warn("║ DEVELOPMENT SECURITY is ACTIVE but Vaadin is running in PRODUCTION mode.               ║");
+                log.warn("║ If you are testing production mode on your local machine, this is fine.                ║");
+                log.warn("║ If you are seeing this in production, you should check your application configuration! ║");
+                log.warn("╚════════════════════════════════════════════════════════════════════════════════════════╝");
             }
             var routeConfiguration = RouteConfiguration.forApplicationScope();
             routeConfiguration.setRoute(DevLoginView.LOGIN_PATH, DevLoginView.class);
         };
+    }
+
+    private boolean isRunningLocally(Environment environment) {
+        boolean hasUserHome = System.getProperty("user.home") != null;
+        CloudPlatform activePlatform = CloudPlatform.getActive(environment);
+
+        log.info("Local environment check - User home: {}, Cloud platform: {}", hasUserHome, activePlatform);
+
+        return hasUserHome && activePlatform == null;
     }
 }


### PR DESCRIPTION
This PR allows the application to start up with development security even though Vaadin has been built in production mode. This is done by introducing a separate `prod` profile that must be activated when running the application in production mode. This is in accordance with established Spring Boot practices.

The development security configuration contains some extra safeguards that stops the application from starting inside a cloud environment.

Closes #110 