### PR TITLE
Use secrets instead of ARG for the keys

### DIFF
--- a/walking-skeleton/Dockerfile
+++ b/walking-skeleton/Dockerfile
@@ -1,17 +1,27 @@
+FROM ghcr.io/jqlang/jq:latest AS jq-stage
+
 FROM eclipse-temurin:21-jdk AS build
+COPY --from=jq-stage /jq /usr/bin/jq
+# Test that jq works after copying
+RUN jq --version
+
 ENV HOME=/app
 RUN mkdir -p $HOME
 WORKDIR $HOME
 COPY . $HOME
 
-# If you have a Vaadin Pro key, pass it as a secret with id "proKey".
-# If you have a Vaadin Offline key, pass it as a secret with id "secretKey".
-# Build the application with production profile
+# If you have a Vaadin Pro key, pass it as a secret with id "proKey":
+#
+#   $ docker build --secret id=proKey,src=$HOME/.vaadin/proKey  .
+#
+# If you have a Vaadin Offline key, pass it as a secret with id "offlineKey":
+#
+#   $ docker build --secret id=offlineKey,src=$HOME/.vaadin/offlineKey  .
 
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=secret,id=proKey \
     --mount=type=secret,id=offlineKey \
-    sh -c 'PRO_KEY=$(cat /run/secrets/proKey 2>/dev/null || echo "") && \
+    sh -c 'PRO_KEY=$(jq -r ".proKey // empty" /run/secrets/proKey || echo "") && \
     OFFLINE_KEY=$(cat /run/secrets/offlineKey 2>/dev/null || echo "") && \
     ./mvnw clean package -Pproduction -DskipTests -Dvaadin.proKey=${PRO_KEY} -Dvaadin.offlineKey=${OFFLINE_KEY}'
 

--- a/walking-skeleton/Dockerfile
+++ b/walking-skeleton/Dockerfile
@@ -12,11 +12,11 @@ COPY . $HOME
 
 # If you have a Vaadin Pro key, pass it as a secret with id "proKey":
 #
-#   $ docker build --secret id=proKey,src=$HOME/.vaadin/proKey  .
+#   $ docker build --secret id=proKey,src=$HOME/.vaadin/proKey .
 #
 # If you have a Vaadin Offline key, pass it as a secret with id "offlineKey":
 #
-#   $ docker build --secret id=offlineKey,src=$HOME/.vaadin/offlineKey  .
+#   $ docker build --secret id=offlineKey,src=$HOME/.vaadin/offlineKey .
 
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=secret,id=proKey \

--- a/walking-skeleton/Dockerfile
+++ b/walking-skeleton/Dockerfile
@@ -21,7 +21,7 @@ COPY . $HOME
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=secret,id=proKey \
     --mount=type=secret,id=offlineKey \
-    sh -c 'PRO_KEY=$(jq -r ".proKey // empty" /run/secrets/proKey || echo "") && \
+    sh -c 'PRO_KEY=$(jq -r ".proKey // empty" /run/secrets/proKey 2>/dev/null || echo "") && \
     OFFLINE_KEY=$(cat /run/secrets/offlineKey 2>/dev/null || echo "") && \
     ./mvnw clean package -Pproduction -DskipTests -Dvaadin.proKey=${PRO_KEY} -Dvaadin.offlineKey=${OFFLINE_KEY}'
 

--- a/walking-skeleton/Dockerfile
+++ b/walking-skeleton/Dockerfile
@@ -4,15 +4,16 @@ RUN mkdir -p $HOME
 WORKDIR $HOME
 COPY . $HOME
 
+# If you have a Vaadin Pro key, pass it as a secret with id "proKey".
+# If you have a Vaadin Offline key, pass it as a secret with id "secretKey".
 # Build the application with production profile
-# Accept VAADIN_PRO_KEY as build argument for commercial components
-ARG VAADIN_PRO_KEY
 
-# If VAADIN_PRO_KEY is provided, use it directly (CI scenario)
-# Otherwise, Vaadin will look for the key in ~/.vaadin/proKey (local build)
-ENV VAADIN_PRO_KEY=${VAADIN_PRO_KEY}
-
-RUN --mount=type=cache,target=/root/.m2 ./mvnw clean package -Pproduction -DskipTests
+RUN --mount=type=cache,target=/root/.m2 \
+    --mount=type=secret,id=proKey \
+    --mount=type=secret,id=offlineKey \
+    sh -c 'PRO_KEY=$(cat /run/secrets/proKey 2>/dev/null || echo "") && \
+    OFFLINE_KEY=$(cat /run/secrets/offlineKey 2>/dev/null || echo "") && \
+    ./mvnw clean package -Pproduction -DskipTests -Dvaadin.proKey=${PRO_KEY} -Dvaadin.offlineKey=${OFFLINE_KEY}'
 
 FROM eclipse-temurin:21-jre-alpine
 COPY --from=build /app/target/*.jar app.jar

--- a/walking-skeleton/README-empty.md
+++ b/walking-skeleton/README-empty.md
@@ -20,3 +20,9 @@ To build a Docker image, run:
 ```bash
 docker build -t my-application:latest .
 ```
+
+If you use commercial components, pass the license key as a build secret:
+
+```bash
+docker build --secret id=proKey,src=$HOME/.vaadin/proKey .
+```

--- a/walking-skeleton/README-flow.md
+++ b/walking-skeleton/README-flow.md
@@ -21,6 +21,12 @@ To build a Docker image, run:
 docker build -t my-application:latest .
 ```
 
+If you use commercial components, pass the license key as a build secret:
+
+```bash
+docker build --secret id=proKey,src=$HOME/.vaadin/proKey .
+```
+
 ## Getting Started
 
 The [Getting Started](https://vaadin.com/docs/latest/getting-started) guide will quickly familiarize you with your new

--- a/walking-skeleton/README-hilla.md
+++ b/walking-skeleton/README-hilla.md
@@ -21,6 +21,12 @@ To build a Docker image, run:
 docker build -t my-application:latest .
 ```
 
+If you use commercial components, pass the license key as a build secret:
+
+```bash
+docker build --secret id=proKey,src=$HOME/.vaadin/proKey .
+```
+
 ## Getting Started
 
 The [Getting Started](https://vaadin.com/docs/latest/getting-started) guide will quickly familiarize you with your new

--- a/walking-skeleton/README-hybrid.md
+++ b/walking-skeleton/README-hybrid.md
@@ -21,6 +21,12 @@ To build a Docker image, run:
 docker build -t my-application:latest .
 ```
 
+If you use commercial components, pass the license key as a build secret:
+
+```bash
+docker build --secret id=proKey,src=$HOME/.vaadin/proKey .
+```
+
 ## Getting Started
 
 The [Getting Started](https://vaadin.com/docs/latest/getting-started) guide will quickly familiarize you with your new


### PR DESCRIPTION
This makes the build safer and also removes the need for a build script (see updated documentation in https://github.com/vaadin/docs/pull/4577).