### PR TITLE
chore: build production package by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN \
 WORKDIR /app/walking-skeleton-generator
 RUN \
  --mount=type=cache,target=/root/.m2 \
- mvn -C clean package -Pproduction
+ mvn -C clean package
 RUN mv target/*.jar target/generator.jar
 
 # Generate config files

--- a/walking-skeleton/Dockerfile
+++ b/walking-skeleton/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=secret,id=offlineKey \
     sh -c 'PRO_KEY=$(jq -r ".proKey // empty" /run/secrets/proKey 2>/dev/null || echo "") && \
     OFFLINE_KEY=$(cat /run/secrets/offlineKey 2>/dev/null || echo "") && \
-    ./mvnw clean package -Pproduction -DskipTests -Dvaadin.proKey=${PRO_KEY} -Dvaadin.offlineKey=${OFFLINE_KEY}'
+    ./mvnw clean package -DskipTests -Dvaadin.proKey=${PRO_KEY} -Dvaadin.offlineKey=${OFFLINE_KEY}'
 
 FROM eclipse-temurin:21-jre-alpine
 COPY --from=build /app/target/*.jar app.jar

--- a/walking-skeleton/README-empty.md
+++ b/walking-skeleton/README-empty.md
@@ -12,7 +12,7 @@ You can also start the application from the command line by running:
 To build the application in production mode, run:
 
 ```bash
-./mvnw -Pproduction package
+./mvnw package
 ```
 
 To build a Docker image, run:

--- a/walking-skeleton/README-flow.md
+++ b/walking-skeleton/README-flow.md
@@ -63,7 +63,7 @@ You can also start the application from the command line by running:
 To build the application in production mode, run:
 
 ```bash
-./mvnw -Pproduction package
+./mvnw package
 ```
 
 To build a Docker image, run:

--- a/walking-skeleton/README-hilla.md
+++ b/walking-skeleton/README-hilla.md
@@ -64,7 +64,7 @@ You can also start the application from the command line by running:
 To build the application in production mode, run:
 
 ```bash
-./mvnw -Pproduction package
+./mvnw package
 ```
 
 To build a Docker image, run:

--- a/walking-skeleton/README-hybrid.md
+++ b/walking-skeleton/README-hybrid.md
@@ -12,7 +12,7 @@ You can also start the application from the command line by running:
 To build the application in production mode, run:
 
 ```bash
-./mvnw -Pproduction package
+./mvnw package
 ```
 
 To build a Docker image, run:

--- a/walking-skeleton/pom.xml
+++ b/walking-skeleton/pom.xml
@@ -12,13 +12,13 @@
 
     <properties>
         <java.version>21</java.version>
-        <vaadin.version>25.0.0-alpha12</vaadin.version>
+        <vaadin.version>25.0.0-beta2</vaadin.version>
     </properties>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-RC1</version>
         <relativePath/>
     </parent>
 
@@ -70,10 +70,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <!-- Set false to exclude optional dependencies like vaadin-dev. -->
-                    <includeOptional>false</includeOptional>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>

--- a/walking-skeleton/pom.xml
+++ b/walking-skeleton/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M3</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -39,6 +39,11 @@
             <groupId>com.vaadin</groupId>
             <!-- Replace artifactId with vaadin-core to use only free components -->
             <artifactId>vaadin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
@@ -65,6 +70,10 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Set false to exclude optional dependencies like vaadin-dev. -->
+                    <includeOptional>false</includeOptional>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
@@ -103,46 +112,17 @@
                             <goal>prepare-frontend</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>package-for-production</id>
+                        <goals>
+                            <goal>build-frontend</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>production</id>
-            <dependencies>
-                <dependency>
-                    <!-- Exclude development dependencies from production -->
-                    <groupId>com.vaadin</groupId>
-                    <artifactId>vaadin-core</artifactId>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>com.vaadin</groupId>
-                            <artifactId>vaadin-dev</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.vaadin</groupId>
-                        <artifactId>vaadin-maven-plugin</artifactId>
-                        <version>${vaadin.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>build-frontend</goal>
-                                </goals>
-                                <phase>compile</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
     <repositories>
         <repository>


### PR DESCRIPTION
Cleans up Maven build configuration by removing need for production profile. Updates Maven build configuration to run build-frontend goal by default on package phase. With help of spring-boot-maven-plugin feature, includeOptional=false, vaadin-dev dependency is not included in production package.

Part of https://github.com/vaadin/flow/issues/22439