### PR TITLE
Resolve repositories in the right order

### DIFF
--- a/walking-skeleton/pom.xml
+++ b/walking-skeleton/pom.xml
@@ -146,19 +146,15 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>             
+        <repository>
             <id>vaadin-directory</id>
             <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
-        <repository>
-            <id>vaadin-prereleases</id>
-            <url>https://maven.vaadin.com/vaadin-prereleases</url>
-        </repository>
     </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>vaadin-prereleases</id>
-            <url>https://maven.vaadin.com/vaadin-prereleases</url>
-        </pluginRepository>
-    </pluginRepositories>
 </project>


### PR DESCRIPTION
Speed up dependency lookups:
* Explicitly define Maven Central first so that lookups start there before checking anything else
* Remove the prerelease repo since we're anyways publishing all relevant prereleases to Maven Central starting from Vaadin 24.9

Together, these changes speed up `mvn package` with an empty Maven cache from 3:32 min to 0:53 min on my M1 Macbook Pro with a wired gigabit network connection.