### PR TITLE
chore: do not fail workflow if there are no changes to commit in branch

### DIFF
--- a/.github/workflows/refresh-branches.yml
+++ b/.github/workflows/refresh-branches.yml
@@ -71,6 +71,9 @@ jobs:
           git config --global user.name "Vaadin Bot"
           git status
           git add --all
-          git commit -am "Refresh branch ${{ env.BRANCH }}"
-          git status
-          git push origin
+          if ! git diff --quiet || ! git diff --cached --quiet; then
+            git commit -m "Refresh branch ${{ env.BRANCH }}"
+            git push origin
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
This fixes failures when there are no changes to commit like in https://github.com/vaadin/walking-skeleton/actions/runs/18868107271/job/53839957037 