### PR TITLE
Include styles.css in empty project

### DIFF
--- a/assembly/src/assembly/empty-skeleton.xml
+++ b/assembly/src/assembly/empty-skeleton.xml
@@ -24,13 +24,8 @@
             </includes>
             <excludes>
                 <exclude>src/main/bundles/**</exclude>
-                <exclude>src/main/frontend/generated/**</exclude>
-                <exclude>src/main/frontend/components/**</exclude>
-                <exclude>src/main/frontend/views/**</exclude>
-                <exclude>src/main/frontend/index.html</exclude>
-                <exclude>src/main/frontend/index.tsx</exclude>
+                <exclude>src/main/frontend/**</exclude>
                 <exclude>src/main/java/**</exclude>
-                <exclude>src/main/resources/META-INF/**</exclude>
                 <exclude>src/test/**</exclude>
             </excludes>
         </fileSet>


### PR DESCRIPTION
In the V25 skeleton, styles.css was no longer included in the empty project as it has been moved. This PR fixes this.