### PR TITLE
chore: cleanup vaadin maven plugin execution config in pom.xml

### DIFF
--- a/walking-skeleton/pom.xml
+++ b/walking-skeleton/pom.xml
@@ -109,15 +109,8 @@
                 <executions>
                     <execution>
                         <goals>
-                            <goal>prepare-frontend</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>package-for-production</id>
-                        <goals>
                             <goal>build-frontend</goal>
                         </goals>
-                        <phase>prepare-package</phase>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Removed unnecessary 'prepare-frontend' goal and 'prepare-package' phase which is now default phase of 'build-frontend' goal.